### PR TITLE
Improve Payu JSON invalid input error

### DIFF
--- a/src/access/parsers/payujson_profiling.py
+++ b/src/access/parsers/payujson_profiling.py
@@ -52,21 +52,23 @@ class PayuJSONProfilingParser(ProfilingParser):
             dict: Parsed timing information.
 
         Raises:
-            KeyError: when "timings" key is missing in input JSON.
-            ValueError: if stream is not a string with valid JSON.
+            ValueError: when input stream is not valid Payu JSON output.
         """
+        errmsg = "No Payu profiling data found"
 
         try:
             timings = json.loads(stream)["timings"]
-        except KeyError:
-            raise KeyError('"timings" key missing in stream.')
-        except json.JSONDecodeError:
-            raise ValueError("Invalid JSON supplied.")
+        except:
+            raise ValueError(errmsg)
 
         # remove known keys not relevant to profiling
         for unwanted_key in ("payu_start_time", "payu_finish_time"):
             if unwanted_key in timings:
                 del timings[unwanted_key]
+
+        # error if no relevant keys in timings
+        if not timings:
+            raise ValueError(errmsg)
 
         result = {"region": [], "walltime": []}
 

--- a/tests/test_payujson_profiling.py
+++ b/tests/test_payujson_profiling.py
@@ -62,9 +62,14 @@ def test_payujson_profiling(payujson_parser, payujson_log_file, payujson_profili
         ), f"Incorrect walltime for region {region} (idx: {idx})."
 
 
-def test_payujson_errors(payujson_parser):
+def test_payujson_incorrect_profiling(payujson_parser):
     """Test that exceptions get raised appropriately."""
-    with pytest.raises(KeyError):
+    # missing "timings" key
+    with pytest.raises(ValueError):
         payujson_parser.read('{"a": 123}')
+    # empty "timings" value
+    with pytest.raises(ValueError):
+        payujson_parser.read('{"timings": {"payu_start_time": "2025-09-16T08:52:50.748807"}}')
+    # invalid JSON altogether
     with pytest.raises(ValueError):
         payujson_parser.read("abc def")


### PR DESCRIPTION
This makes a small change to the raised exception(s) in payu json to match what's in fms and cice5 profiling parsers. 