### PR TITLE
Added the custom CICE exes and the UM core counts need to be strings

### DIFF
--- a/src/access/config/esm1p6_layout_input.py
+++ b/src/access/config/esm1p6_layout_input.py
@@ -642,7 +642,8 @@ def generate_esm1p6_perturb_block(
               - {mom_ncores} # ncores for ocean
           - ncpus: # ice
               - {ice_ncores} # ncores for ice
-          - exe: cice_access-esm1.6_360x300_{ice_ncores}x1_{ice_ncores}p.exe
+            exe:
+              - cice_access-esm1.6_360x300_{ice_ncores}x1_{ice_ncores}p.exe
 
     atmosphere/um_env.yaml:
       UM_ATM_NPROCX: "{atm_nx}"


### PR DESCRIPTION
experiment-runner was not working for these two bugs:

- missing CICE exe names for the custom cores
- the three fields related to UM core counts needed to be strings (experiment runner raised an error)

This new setup works for 4 nodes - but we should wait to merge this until I have confirmed that the setup works for other node counts as well. 

