### PR TITLE
Refactor the config parser base classes

### DIFF
--- a/src/access/config/parse_tree_ops.py
+++ b/src/access/config/parse_tree_ops.py
@@ -1,0 +1,221 @@
+# Copyright 2025 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Functions and classes for manipulating Lark parse trees.
+
+This module contains the low-level tree operations used by the configuration
+parser: updating node values, locating rule nodes, annotating parent references,
+and converting a parse tree into a dictionary of values and references.
+"""
+
+from typing import Any
+
+from lark import Token, Tree, Visitor
+from lark.reconstruct import Reconstructor
+from lark.visitors import Interpreter
+
+from access.config.parser_types import VALUE_TYPE_HANDLER_REGISTRY
+
+
+def update_node_value(branch: Tree, value: Any) -> None:
+    """Updates the value stored in a Lark tree branch.
+
+    The branch should store a value rule of the appropriate type.  Uses the
+    ``VALUE_TYPE_HANDLER_REGISTRY`` to look up the appropriate handler.
+
+    Args:
+        branch (Tree): Tree branch to update.
+        value (Any): New value.
+
+    Raises:
+        TypeError: Raises an exception if the new and old value types do not match.
+    """
+    handler = VALUE_TYPE_HANDLER_REGISTRY.get(getattr(branch, "data", None))
+    if handler is None or not handler.type_check(value):
+        raise TypeError("Trying to change value type")
+    transformed_value = handler.to_token(value, branch.children[0])
+    branch.children[0] = branch.children[0].update(value=transformed_value)  # type: ignore
+
+
+def find_rule_node(ref: Any) -> Tree:
+    """Given a parse-tree reference for a key, return the corresponding rule node.
+
+    Different rule types store refs differently:
+        - ``key_list``: *ref* is a list of value nodes; the rule is the parent of any element.
+        - ``key_null``: *ref* is the rule node itself.
+        - ``key_value`` / ``key_block``: *ref* is a child node; the rule is its parent.
+
+        Args:
+            ref: The reference to find the rule for.
+
+        Returns:
+            Tree: The rule node.
+    """
+    if isinstance(ref, list):
+        return ref[0].parent
+    elif hasattr(ref, "data") and ref.data.startswith("key_"):
+        return ref
+    else:
+        return ref.parent
+
+
+class AddParent(Visitor):
+    """Lark visitor that adds to every node in the tree a reference to its parent."""
+
+    def __default__(self, tree):
+        for subtree in tree.children:
+            if isinstance(subtree, Tree):
+                assert not hasattr(subtree, "parent")
+                subtree.parent = tree  # type: ignore
+
+
+class ConfigToDict(Interpreter):
+    """Interpreter to be used by Lark to create a dict holding the config data and the corresponding dict of references
+    to the branches of the parse tree.
+
+    When using Lark, the usual way to transform the parse tree into something else is to use a Transformer.
+    Here we use an Interpreter instead, as this allows us to create a dict of references to the branches of the
+    original tree. The Interpreter will also skip visiting sub-branches, allowing us to handle entire branches in a
+    single function.
+
+    While processing blocks, instances of this class need extra information to instantiate a ``Config``. We store that
+    extra information as private class arguments.
+
+    Args:
+        reconstructor (Reconstructor): Lark reconstructor created from the parser.
+        case_sensitive_keys (bool): Are keys case-sensitive?
+    """
+
+    _data: dict  # Private dictionary used to store the config data while traversing the tree.
+    _refs: dict  # Private dictionary used to store the references while traversing the tree.
+    _reconstructor: Reconstructor  # Lark reconstructor.
+    _case_sensitive_keys: bool  # Are keys case-sensitive?
+
+    def __init__(self, reconstructor: Reconstructor, case_sensitive_keys: bool) -> None:
+        self._reconstructor = reconstructor
+        self._case_sensitive_keys = case_sensitive_keys
+        super().__init__()
+
+    def visit(self, tree: Tree) -> tuple[dict[str, Any], dict[str, Tree]]:
+        """Visit the entire tree and return two dictionaries: one holding the parsed items and the other one holding,
+        for each parsed item, a reference to the corresponding tree branch.
+
+        Args:
+            tree (Tree): Tree to visit.
+
+        Returns:
+            Tuple[Dict[str, Any], Dict[str, Tree]]: Dict holding the parsed values, dict holding the references to the
+            branches.
+        """
+        self._data = {}
+        self._refs = {}
+        super().visit(tree)
+        return self._data, self._refs
+
+    def _get_key(self, tree: Tree) -> str:
+        """Given a tree, look for the token storing a key name and return it.
+
+        Args:
+            tree (Tree): Lark tree storing a "key" rule.
+
+        Raises:
+            TypeError: If no key is found.
+
+        Returns:
+            str: The key.
+
+        """
+        key_node = [child.children[0] for child in tree.children if child.data == "key"][0]
+        if isinstance(key_node, Token):
+            key = key_node.value
+        else:
+            raise TypeError("No key found.")
+
+        if self._case_sensitive_keys:
+            return key
+        else:
+            return key.upper()
+
+    def _transform_values(self, children: list[Tree]) -> tuple[list[Any], list[Tree]]:
+        """Given the children of a "key_value" or a "key_list" rule, extract and transform the corresponding values.
+
+        Args:
+            children (List[Tree]): List of Lark trees containing the values to process. These should be the children
+                of a "key_value" or a "key_list" rule.
+
+        Raises:
+            ValueError: If no values are found.
+
+        Returns:
+            Tuple[List[Any], List[Tree]]: List of transformed values, list of tree branches storing the corresponding
+                values.
+        """
+        refs = [child for child in children if child.data in VALUE_TYPE_HANDLER_REGISTRY]
+        if len(refs) == 0:
+            raise ValueError("No values found in Tree")
+        values = [VALUE_TYPE_HANDLER_REGISTRY[child.data].from_token(child.children[0]) for child in refs]
+        return values, refs
+
+    def _transform_value(self, children: list[Tree]) -> tuple[Any, Tree]:
+        """Given the children of a "key_value" rule, extract and transform the corresponding value.
+
+        Args:
+            children (List[Tree]): List of Lark branches containing the value to process. These should be the children
+                of a "key_value" rule.
+
+        Raises:
+            ValueError: If more than one value is found.
+
+        Returns:
+            Tuple[Any, Tree]: Transformed value, tree branch storing the corresponding value.
+        """
+        values, refs = self._transform_values(children)
+        if len(refs) > 1:
+            raise ValueError("More than one value found in Tree")
+        return values[0], refs[0]
+
+    def key_list(self, tree: Tree) -> None:
+        """Function to process "key_list" rules.
+
+        Args:
+            tree (Tree): Lark tree storing a "key_list" rule.
+        """
+        key = self._get_key(tree)
+        self._data[key], self._refs[key] = self._transform_values(tree.children)
+
+    def key_value(self, tree: Tree) -> None:
+        """Function to process "key_value" rules.
+
+        Args:
+            tree (Tree): Lark tree storing a "key_value" rule.
+        """
+        key = self._get_key(tree)
+        self._data[key], self._refs[key] = self._transform_value(tree.children)
+
+    def key_block(self, tree: Tree) -> None:
+        """Function to process "key_block" rules.
+
+        Args:
+            tree (Tree): Lark tree storing a "key_block" rule.
+        """
+        # Lazy import to avoid circular dependency (Config -> ConfigToDict -> Config)
+        from access.config.parser import Config
+
+        key = self._get_key(tree)
+        for child in tree.children:
+            if child.data == "block":
+                self._data[key] = Config(child, self._reconstructor, self._case_sensitive_keys)
+                self._refs[key] = child
+                return
+            else:
+                pass
+
+    def key_null(self, tree: Tree) -> None:
+        """Function to process "key_null" rules.
+
+        Args:
+            tree (Tree): Lark tree storing a "key_null" rule.
+        """
+        key = self._get_key(tree)
+        self._data[key] = None
+        self._refs[key] = tree

--- a/src/access/config/parse_tree_ops.py
+++ b/src/access/config/parse_tree_ops.py
@@ -8,6 +8,8 @@ parser: updating node values, locating rule nodes, annotating parent references,
 and converting a parse tree into a dictionary of values and references.
 """
 
+from __future__ import annotations
+
 from typing import Any
 
 from lark import Token, Tree, Visitor
@@ -30,14 +32,17 @@ def update_node_value(branch: Tree, value: Any) -> None:
     Raises:
         TypeError: Raises an exception if the new and old value types do not match.
     """
-    handler = VALUE_TYPE_HANDLER_REGISTRY.get(getattr(branch, "data", None))
+    data_name: str | None = getattr(branch, "data", None)
+    handler = VALUE_TYPE_HANDLER_REGISTRY.get(data_name)
     if handler is None or not handler.type_check(value):
         raise TypeError("Trying to change value type")
-    transformed_value = handler.to_token(value, branch.children[0])
-    branch.children[0] = branch.children[0].update(value=transformed_value)  # type: ignore
+    token = branch.children[0]
+    assert isinstance(token, Token)
+    transformed_value = handler.to_token(value, str(token))
+    branch.children[0] = token.update(value=transformed_value)
 
 
-def find_rule_node(ref: Any) -> Tree:
+def find_rule_node(ref: list[Tree] | Tree) -> Tree:
     """Given a parse-tree reference for a key, return the corresponding rule node.
 
     Different rule types store refs differently:
@@ -52,17 +57,17 @@ def find_rule_node(ref: Any) -> Tree:
             Tree: The rule node.
     """
     if isinstance(ref, list):
-        return ref[0].parent
+        return ref[0].parent  # type: ignore[attr-defined]
     elif hasattr(ref, "data") and ref.data.startswith("key_"):
         return ref
     else:
-        return ref.parent
+        return ref.parent  # type: ignore[attr-defined]
 
 
 class AddParent(Visitor):
     """Lark visitor that adds to every node in the tree a reference to its parent."""
 
-    def __default__(self, tree):
+    def __default__(self, tree: Tree) -> None:
         for subtree in tree.children:
             if isinstance(subtree, Tree):
                 assert not hasattr(subtree, "parent")
@@ -86,8 +91,8 @@ class ConfigToDict(Interpreter):
         case_sensitive_keys (bool): Are keys case-sensitive?
     """
 
-    _data: dict  # Private dictionary used to store the config data while traversing the tree.
-    _refs: dict  # Private dictionary used to store the references while traversing the tree.
+    _data: dict[str, Any]  # Private dictionary used to store the config data while traversing the tree.
+    _refs: dict[str, list[Tree] | Tree]  # Private dictionary used to store the references while traversing the tree.
     _reconstructor: Reconstructor  # Lark reconstructor.
     _case_sensitive_keys: bool  # Are keys case-sensitive?
 
@@ -96,7 +101,7 @@ class ConfigToDict(Interpreter):
         self._case_sensitive_keys = case_sensitive_keys
         super().__init__()
 
-    def visit(self, tree: Tree) -> tuple[dict[str, Any], dict[str, Tree]]:
+    def visit(self, tree: Tree) -> tuple[dict[str, Any], dict[str, list[Tree] | Tree]]:
         """Visit the entire tree and return two dictionaries: one holding the parsed items and the other one holding,
         for each parsed item, a reference to the corresponding tree branch.
 
@@ -104,8 +109,8 @@ class ConfigToDict(Interpreter):
             tree (Tree): Tree to visit.
 
         Returns:
-            Tuple[Dict[str, Any], Dict[str, Tree]]: Dict holding the parsed values, dict holding the references to the
-            branches.
+            tuple[dict[str, Any], dict[str, list[Tree] | Tree]]: Dict holding the parsed values, dict holding the
+            references to the branches.
         """
         self._data = {}
         self._refs = {}
@@ -153,7 +158,7 @@ class ConfigToDict(Interpreter):
         refs = [child for child in children if child.data in VALUE_TYPE_HANDLER_REGISTRY]
         if len(refs) == 0:
             raise ValueError("No values found in Tree")
-        values = [VALUE_TYPE_HANDLER_REGISTRY[child.data].from_token(child.children[0]) for child in refs]
+        values = [VALUE_TYPE_HANDLER_REGISTRY[child.data].from_token(str(child.children[0])) for child in refs]
         return values, refs
 
     def _transform_value(self, children: list[Tree]) -> tuple[Any, Tree]:
@@ -198,13 +203,13 @@ class ConfigToDict(Interpreter):
         Args:
             tree (Tree): Lark tree storing a "key_block" rule.
         """
-        # Lazy import to avoid circular dependency (Config -> ConfigToDict -> Config)
-        from access.config.parser import Config
+        # Import here to avoid circular dependency (Config -> ConfigToDict -> Config)
+        from access.config.parser import Config as ConfigImpl
 
         key = self._get_key(tree)
         for child in tree.children:
             if child.data == "block":
-                self._data[key] = Config(child, self._reconstructor, self._case_sensitive_keys)
+                self._data[key] = ConfigImpl(child, self._reconstructor, self._case_sensitive_keys)
                 self._refs[key] = child
                 return
             else:

--- a/src/access/config/parse_tree_ops.py
+++ b/src/access/config/parse_tree_ops.py
@@ -180,9 +180,16 @@ class ConfigToDict(Interpreter):
             str: The key name (uppercased if keys are case-insensitive).
 
         """
-        # Get the first child of the "key" rule node among the children of *tree*.
-        # This is the Token holding the key string.
-        key_token = [child.children[0] for child in tree.children if child.data == "key"][0]
+        key_rules = [child.children for child in tree.children if child.data == "key"]
+        if len(key_rules) == 0:
+            raise ValueError("No 'key' rule nodes found among children of key rule node")
+        else:
+            # Multiple "key" rule nodes are possible (e.g., if the tree is a key_block storing one of more key_values)
+            # but the correct one should always be the first one.
+            key_rule = key_rules[0]
+
+        # The token holding the key name is the first child of the "key" rule node.
+        key_token = key_rule[0]
         if isinstance(key_token, Token):
             key = key_token.value
         else:

--- a/src/access/config/parse_tree_ops.py
+++ b/src/access/config/parse_tree_ops.py
@@ -6,6 +6,40 @@
 This module contains the low-level tree operations used by the configuration
 parser: updating node values, locating rule nodes, annotating parent references,
 and converting a parse tree into a dictionary of values and references.
+
+Lark parse tree structure
+-------------------------
+A Lark parse tree is made up of two node types that correspond directly to
+grammar elements:
+
+``Tree``: produced by a **grammar rule** (lowercase name in the grammar)
+    - ``tree.data`` (``str``): the rule name, e.g. ``"key_value"``, ``"integer"``
+    - ``tree.children`` (``list``): child nodes, each a ``Tree`` or ``Token``
+
+``Token``: produced by a **grammar terminal** (UPPERCASE name in the grammar)
+    - ``Token`` is a subclass of ``str``, so it compares and behaves like the
+      matched text directly (e.g. ``token == "42"``).
+    - ``token.type`` (``str``): the terminal name, e.g. ``"CNAME"``, ``"INT"``
+    - Tokens are always **leaf nodes**, as such they have no children.
+
+Because ``Token`` inherits from ``str``, code that only needs the matched text
+can use a ``Token`` directly as a string without calling ``.value``.
+
+Grammar structure assumptions
+------------------------------
+All grammars used with this module must follow these conventions:
+
+- Key-value assignments use rules named (or aliased to) ``"key_value"``,
+  ``"key_list"``, ``"key_block"``, or ``"key_null"``.
+- The rule identifying the key name must be named ``"key"``, must have a
+  terminal (e.g. ``CNAME``) as its first child and that terminal's text is the
+  key string.
+- Value types (e.g. integers, floats, logicals) are expressed as dedicated
+  rules whose names are registered in ``VALUE_TYPE_HANDLER_REGISTRY``. Each
+  such **value-type rule node** has a single ``Token`` child holding the
+  matched text.
+- Whitespace that must be preserved for round-trip fidelity is captured in an
+  explicit ``ws`` rule rather than discarded with ``%ignore``.
 """
 
 from __future__ import annotations
@@ -19,53 +53,65 @@ from lark.visitors import Interpreter
 from access.config.parser_types import VALUE_TYPE_HANDLER_REGISTRY
 
 
-def update_node_value(branch: Tree, value: Any) -> None:
-    """Updates the value stored in a Lark tree branch.
+def update_node_value(rule_node: Tree, value: Any) -> None:
+    """Updates the value stored in a value-type rule node.
 
-    The branch should store a value rule of the appropriate type.  Uses the
-    ``VALUE_TYPE_HANDLER_REGISTRY`` to look up the appropriate handler.
+    The rule node must be a ``Tree`` whose ``.data`` is a key in ``VALUE_TYPE_HANDLER_REGISTRY``
+    (e.g. ``"integer"``, ``"float"``). The handler is looked up from that registry.
 
     Args:
-        branch (Tree): Tree branch to update.
+        rule_node (Tree): Value-type rule node to update.
         value (Any): New value.
 
     Raises:
         TypeError: Raises an exception if the new and old value types do not match.
     """
-    data_name: str | None = getattr(branch, "data", None)
+    data_name: str | None = getattr(rule_node, "data", None)
     handler = VALUE_TYPE_HANDLER_REGISTRY.get(data_name)
     if handler is None or not handler.type_check(value):
         raise TypeError("Trying to change value type")
-    token = branch.children[0]
+    # The Token storing the value is always the first child of a value-type rule node.
+    token = rule_node.children[0]
     assert isinstance(token, Token)
     transformed_value = handler.to_token(value, str(token))
-    branch.children[0] = token.update(value=transformed_value)
+    rule_node.children[0] = token.update(value=transformed_value)
 
 
 def find_rule_node(ref: list[Tree] | Tree) -> Tree:
-    """Given a parse-tree reference for a key, return the corresponding rule node.
+    """Given a parse-tree reference for a key, return the corresponding key rule node.
 
-    Different rule types store refs differently:
-        - ``key_list``: *ref* is a list of value nodes; the rule is the parent of any element.
-        - ``key_null``: *ref* is the rule node itself.
-        - ``key_value`` / ``key_block``: *ref* is a child node; the rule is its parent.
+    References are stored differently depending on the key rule type:
 
-        Args:
-            ref: The reference to find the rule for.
+    - ``key_list``: *ref* is a list of value-type rule nodes (one per list element);
+      the key rule node is the ``.parent`` of any element.
+    - ``key_null``: *ref* is the key rule node itself.
+    - ``key_value`` / ``key_block``: *ref* is a value-type rule node (child of the key
+      rule node); the key rule node is its ``.parent``.
 
-        Returns:
-            Tree: The rule node.
+    Args:
+        ref: A value-type rule node, a list of value-type rule nodes, or a key rule node,
+            as stored in ``_refs``.
+
+    Returns:
+        Tree: The key rule node (``Tree`` whose ``.data`` starts with ``"key_"``).
     """
     if isinstance(ref, list):
         return ref[0].parent  # type: ignore[attr-defined]
     elif hasattr(ref, "data") and ref.data.startswith("key_"):
+        # Note that, although ``key_value`` and ``key_block`` contain ``key_`` in their names, the refs stored for these
+        # types are **children** of the key rule node, so their ``.data`` does not start with ``"key_"``.
         return ref
     else:
         return ref.parent  # type: ignore[attr-defined]
 
 
 class AddParent(Visitor):
-    """Lark visitor that adds to every node in the tree a reference to its parent."""
+    """Lark visitor that annotates every ``Tree`` node with a ``.parent`` back-reference.
+
+    ``Token`` children (terminal leaves) are skipped and only ``Tree`` children (rule nodes)
+    receive the ``.parent`` attribute. This enables upward traversal of the parse tree,
+    which Lark does not provide natively.
+    """
 
     def __default__(self, tree: Tree) -> None:
         for subtree in tree.children:
@@ -76,12 +122,12 @@ class AddParent(Visitor):
 
 class ConfigToDict(Interpreter):
     """Interpreter to be used by Lark to create a dict holding the config data and the corresponding dict of references
-    to the branches of the parse tree.
+    to rule nodes in the parse tree.
 
-    When using Lark, the usual way to transform the parse tree into something else is to use a Transformer.
-    Here we use an Interpreter instead, as this allows us to create a dict of references to the branches of the
-    original tree. The Interpreter will also skip visiting sub-branches, allowing us to handle entire branches in a
-    single function.
+    A Lark ``Transformer`` would be the usual choice, but it replaces rule nodes with transformed values, destroying
+    the original tree.  Using an ``Interpreter`` instead lets us retain references to the original rule nodes so that
+    they can be mutated later to support round-trip editing.  The ``Interpreter`` also skips visiting child rule nodes
+    automatically, so each callback handles an entire key rule subtree in one call.
 
     While processing blocks, instances of this class need extra information to instantiate a ``Config``. We store that
     extra information as private class arguments.
@@ -91,8 +137,10 @@ class ConfigToDict(Interpreter):
         case_sensitive_keys (bool): Are keys case-sensitive?
     """
 
-    _data: dict[str, Any]  # Private dictionary used to store the config data while traversing the tree.
-    _refs: dict[str, list[Tree] | Tree]  # Private dictionary used to store the references while traversing the tree.
+    _data: dict[str, Any]  # Config data accumulated while traversing the tree.
+    _refs: dict[str, list[Tree] | Tree]  # References to rule nodes in the parse tree, keyed by config key.
+    # For key_list: a list of value-type rule nodes (one per element).
+    # For key_value / key_block / key_null: a single rule node.
     _reconstructor: Reconstructor  # Lark reconstructor.
     _case_sensitive_keys: bool  # Are keys case-sensitive?
 
@@ -102,15 +150,14 @@ class ConfigToDict(Interpreter):
         super().__init__()
 
     def visit(self, tree: Tree) -> tuple[dict[str, Any], dict[str, list[Tree] | Tree]]:
-        """Visit the entire tree and return two dictionaries: one holding the parsed items and the other one holding,
-        for each parsed item, a reference to the corresponding tree branch.
+        """Visit the entire tree and return two dictionaries: one holding the parsed values and the other holding,
+        for each config key, a reference to the corresponding rule node (or list of rule nodes) in the parse tree.
 
         Args:
-            tree (Tree): Tree to visit.
+            tree (Tree): Root rule node to visit.
 
         Returns:
-            tuple[dict[str, Any], dict[str, list[Tree] | Tree]]: Dict holding the parsed values, dict holding the
-            references to the branches.
+            tuple[dict[str, Any], dict[str, list[Tree] | Tree]]: Dict of parsed values, dict of rule node references.
         """
         self._data = {}
         self._refs = {}
@@ -118,21 +165,26 @@ class ConfigToDict(Interpreter):
         return self._data, self._refs
 
     def _get_key(self, tree: Tree) -> str:
-        """Given a tree, look for the token storing a key name and return it.
+        """Given a key rule node, extract and return the key name.
+
+        Finds the ``"key"`` rule node among *tree*'s children, then reads the ``Token``
+        (terminal) that is its first child and that token's text is the key name.
 
         Args:
-            tree (Tree): Lark tree storing a "key" rule.
+            tree (Tree): A key rule node (e.g. ``Tree`` with ``.data == "key_value"``).
 
         Raises:
-            TypeError: If no key is found.
+            TypeError: If no ``Token`` is found as the first child of the ``"key"`` rule node.
 
         Returns:
-            str: The key.
+            str: The key name (uppercased if keys are case-insensitive).
 
         """
-        key_node = [child.children[0] for child in tree.children if child.data == "key"][0]
-        if isinstance(key_node, Token):
-            key = key_node.value
+        # Get the first child of the "key" rule node among the children of *tree*.
+        # This is the Token holding the key string.
+        key_token = [child.children[0] for child in tree.children if child.data == "key"][0]
+        if isinstance(key_token, Token):
+            key = key_token.value
         else:
             raise TypeError("No key found.")
 
@@ -142,66 +194,68 @@ class ConfigToDict(Interpreter):
             return key.upper()
 
     def _transform_values(self, children: list[Tree]) -> tuple[list[Any], list[Tree]]:
-        """Given the children of a "key_value" or a "key_list" rule, extract and transform the corresponding values.
+        """Given the child nodes of a ``"key_value"`` or ``"key_list"`` rule node, extract and convert the values.
+
+        Filters *children* to those whose ``.data`` is registered in ``VALUE_TYPE_HANDLER_REGISTRY``
+        (i.e. value-type rule nodes such as ``"integer"`` or ``"float"``), then reads the ``Token``
+        child of each to obtain the matched text and converts it to a Python value.
 
         Args:
-            children (List[Tree]): List of Lark trees containing the values to process. These should be the children
-                of a "key_value" or a "key_list" rule.
+            children (List[Tree]): Child nodes of a ``"key_value"`` or ``"key_list"`` rule node.
 
         Raises:
-            ValueError: If no values are found.
+            ValueError: If no value-type rule nodes are found among the children.
 
         Returns:
-            Tuple[List[Any], List[Tree]]: List of transformed values, list of tree branches storing the corresponding
-                values.
+            Tuple[List[Any], List[Tree]]: List of Python values, list of the corresponding
+                value-type rule nodes (for storing in ``_refs``).
         """
-        refs = [child for child in children if child.data in VALUE_TYPE_HANDLER_REGISTRY]
-        if len(refs) == 0:
+        value_rule_nodes = [child for child in children if child.data in VALUE_TYPE_HANDLER_REGISTRY]
+        if len(value_rule_nodes) == 0:
             raise ValueError("No values found in Tree")
-        values = [VALUE_TYPE_HANDLER_REGISTRY[child.data].from_token(str(child.children[0])) for child in refs]
-        return values, refs
+        values = [VALUE_TYPE_HANDLER_REGISTRY[node.data].from_token(str(node.children[0])) for node in value_rule_nodes]
+        return values, value_rule_nodes
 
     def _transform_value(self, children: list[Tree]) -> tuple[Any, Tree]:
-        """Given the children of a "key_value" rule, extract and transform the corresponding value.
+        """Given the child nodes of a ``"key_value"`` rule node, extract and convert the single value.
 
         Args:
-            children (List[Tree]): List of Lark branches containing the value to process. These should be the children
-                of a "key_value" rule.
+            children (List[Tree]): Child nodes of a ``"key_value"`` rule node.
 
         Raises:
-            ValueError: If more than one value is found.
+            ValueError: If more than one value-type rule node is found.
 
         Returns:
-            Tuple[Any, Tree]: Transformed value, tree branch storing the corresponding value.
+            Tuple[Any, Tree]: The Python value and the corresponding value-type rule node.
         """
-        values, refs = self._transform_values(children)
-        if len(refs) > 1:
+        values, value_rule_nodes = self._transform_values(children)
+        if len(value_rule_nodes) > 1:
             raise ValueError("More than one value found in Tree")
-        return values[0], refs[0]
+        return values[0], value_rule_nodes[0]
 
     def key_list(self, tree: Tree) -> None:
-        """Function to process "key_list" rules.
+        """Interpreter callback for ``"key_list"`` rule nodes.
 
         Args:
-            tree (Tree): Lark tree storing a "key_list" rule.
+            tree (Tree): Rule node produced by the ``"key_list"`` grammar rule.
         """
         key = self._get_key(tree)
         self._data[key], self._refs[key] = self._transform_values(tree.children)
 
     def key_value(self, tree: Tree) -> None:
-        """Function to process "key_value" rules.
+        """Interpreter callback for ``"key_value"`` rule nodes.
 
         Args:
-            tree (Tree): Lark tree storing a "key_value" rule.
+            tree (Tree): Rule node produced by the ``"key_value"`` grammar rule.
         """
         key = self._get_key(tree)
         self._data[key], self._refs[key] = self._transform_value(tree.children)
 
     def key_block(self, tree: Tree) -> None:
-        """Function to process "key_block" rules.
+        """Interpreter callback for ``"key_block"`` rule nodes.
 
         Args:
-            tree (Tree): Lark tree storing a "key_block" rule.
+            tree (Tree): Rule node produced by the ``"key_block"`` grammar rule.
         """
         # Import here to avoid circular dependency (Config -> ConfigToDict -> Config)
         from access.config.parser import Config as ConfigImpl
@@ -216,10 +270,10 @@ class ConfigToDict(Interpreter):
                 pass
 
     def key_null(self, tree: Tree) -> None:
-        """Function to process "key_null" rules.
+        """Interpreter callback for ``"key_null"`` rule nodes.
 
         Args:
-            tree (Tree): Lark tree storing a "key_null" rule.
+            tree (Tree): Rule node produced by the ``"key_null"`` grammar rule.
         """
         key = self._get_key(tree)
         self._data[key] = None

--- a/src/access/config/parser.py
+++ b/src/access/config/parser.py
@@ -13,11 +13,10 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any
 
-from lark import Lark, Token, Tree, Visitor
+from lark import Lark, Tree
 from lark.reconstruct import Reconstructor
-from lark.visitors import Interpreter
 
-from access.config.parser_types import VALUE_TYPE_HANDLER_REGISTRY
+from access.config.parse_tree_ops import AddParent, ConfigToDict, find_rule_node, update_node_value
 
 
 class ConfigList(list):
@@ -57,53 +56,11 @@ class ConfigList(list):
             if len(values) != len(refs_slice):
                 raise ValueError(f"Slice assignment would change list length from {len(refs_slice)} to {len(values)}")
             for ref, v in zip(refs_slice, values, strict=True):
-                _update_node_value(ref, v)
+                update_node_value(ref, v)
             super().__setitem__(index, values)
         else:
-            _update_node_value(self._refs[index], value)
+            update_node_value(self._refs[index], value)
             super().__setitem__(index, value)
-
-
-def _update_node_value(branch: Tree, value: Any) -> None:
-    """Updates the value stored in a Lark tree branch.
-
-    The branch should store a value rule of the appropriate type.  Uses the
-    ``_value_type_handlers`` registry to look up the appropriate handler.
-
-    Args:
-        branch (Tree): Tree branch to update.
-        value (Any): New value.
-
-    Raises:
-        TypeError: Raises an exception if the new and old value types do not match.
-    """
-    handler = VALUE_TYPE_HANDLER_REGISTRY.get(getattr(branch, "data", None))
-    if handler is None or not handler.type_check(value):
-        raise TypeError("Trying to change value type")
-    transformed_value = handler.to_token(value, branch.children[0])
-    branch.children[0] = branch.children[0].update(value=transformed_value)  # type: ignore
-
-
-def _find_rule_node(ref: Any) -> Tree:
-    """Given a parse-tree reference for a key, return the corresponding rule node.
-
-    Different rule types store refs differently:
-        - ``key_list``: *ref* is a list of value nodes; the rule is the parent of any element.
-        - ``key_null``: *ref* is the rule node itself.
-        - ``key_value`` / ``key_block``: *ref* is a child node; the rule is its parent.
-
-        Args:
-            ref: The reference to find the rule for.
-
-        Returns:
-            Tree: The rule node.
-    """
-    if isinstance(ref, list):
-        return ref[0].parent
-    elif hasattr(ref, "data") and ref.data.startswith("key_"):
-        return ref
-    else:
-        return ref.parent
 
 
 class Config(dict):
@@ -173,7 +130,7 @@ class Config(dict):
             raise ValueError(f"Trying to change the length of list '{key}'")
 
         for branch, v in zip(refs, value, strict=True):
-            _update_node_value(branch, v)
+            update_node_value(branch, v)
 
         return ConfigList(value, refs)
 
@@ -222,7 +179,7 @@ class Config(dict):
             value = self._update_list_value(key, value)
 
         else:
-            _update_node_value(self._refs[key], value)
+            update_node_value(self._refs[key], value)
 
         super().__setitem__(key, value)
 
@@ -235,7 +192,7 @@ class Config(dict):
         super().__delitem__(key)
 
         # Remove the corresponding rule from the parse tree
-        rule = _find_rule_node(self._refs[key])
+        rule = find_rule_node(self._refs[key])
         rule.parent.children.remove(rule)
 
         # Finally remove reference to the branch storing the value
@@ -246,16 +203,6 @@ class Config(dict):
         if dict(self) == {}:
             return ""
         return self._reconstruct()
-
-
-class AddParent(Visitor):
-    """Lark visitor that adds to every node in the tree a reference to its parent."""
-
-    def __default__(self, tree):
-        for subtree in tree.children:
-            if isinstance(subtree, Tree):
-                assert not hasattr(subtree, "parent")
-                subtree.parent = tree  # type: ignore
 
 
 class ConfigParser(ABC):
@@ -318,152 +265,3 @@ class ConfigParser(ABC):
         AddParent().visit(tree)
         reconstructor = Reconstructor(parser)
         return Config(tree, reconstructor, self.case_sensitive_keys)
-
-
-class ConfigToDict(Interpreter):
-    """Interpreter to be used by Lark to create a dict holding the config data and the corresponding dict of references
-    to the branches of the parse tree.
-
-    When using Lark, the usual way to transform the parse tree into something else is to use a Transformer.
-    Here we use an Interpreter instead, as this allows us to create a dict of references to the branches of the
-    original tree. The Interpreter will also skip visiting sub-branches, allowing us to handle entire branches in a
-    single function.
-
-    While processing blocks, instances of this class need extra information to instantiate a ``Config``. We store that
-    extra information as private class arguments.
-
-    Args:
-        reconstructor (Reconstructor): Lark reconstructor created from the parser.
-        case_sensitive_keys (bool): Are keys case-sensitive?
-    """
-
-    _data: dict  # Private dictionary used to store the config data while traversing the tree.
-    _refs: dict  # Private dictionary used to store the references while traversing the tree.
-    _reconstructor: Reconstructor  # Lark reconstructor.
-    _case_sensitive_keys: bool  # Are keys case-sensitive?
-
-    def __init__(self, reconstructor: Reconstructor, case_sensitive_keys: bool) -> None:
-        self._reconstructor = reconstructor
-        self._case_sensitive_keys = case_sensitive_keys
-        super().__init__()
-
-    def visit(self, tree: Tree) -> tuple[dict[str, Any], dict[str, Tree]]:
-        """Visit the entire tree and return two dictionaries: one holding the parsed items and the other one holding,
-        for each parsed item, a reference to the corresponding tree branch.
-
-        Args:
-            tree (Tree): Tree to visit.
-
-        Returns:
-            Tuple[Dict[str, Any], Dict[str, Tree]]: Dict holding the parsed values, dict holding the references to the
-            branches.
-        """
-        self._data = {}
-        self._refs = {}
-        super().visit(tree)
-        return self._data, self._refs
-
-    def _get_key(self, tree: Tree) -> str:
-        """Given a tree, look for the token storing a key name and return it.
-
-        Args:
-            tree (Tree): Lark tree storing a "key" rule.
-
-        Raises:
-            TypeError: If no key is found.
-
-        Returns:
-            str: The key.
-
-        """
-        key_node = [child.children[0] for child in tree.children if child.data == "key"][0]
-        if isinstance(key_node, Token):
-            key = key_node.value
-        else:
-            raise TypeError("No key found.")
-
-        if self._case_sensitive_keys:
-            return key
-        else:
-            return key.upper()
-
-    def _transform_values(self, children: list[Tree]) -> tuple[list[Any], list[Tree]]:
-        """Given the children of a "key_value" or a "key_list" rule, extract and transform the corresponding values.
-
-        Args:
-            children (List[Tree]): List of Lark trees containing the values to process. These should be the children
-                of a "key_value" or a "key_list" rule.
-
-        Raises:
-            ValueError: If no values are found.
-
-        Returns:
-            Tuple[List[Any], List[Tree]]: List of transformed values, list of tree branches storing the corresponding
-                values.
-        """
-        refs = [child for child in children if child.data in VALUE_TYPE_HANDLER_REGISTRY]
-        if len(refs) == 0:
-            raise ValueError("No values found in Tree")
-        values = [VALUE_TYPE_HANDLER_REGISTRY[child.data].from_token(child.children[0]) for child in refs]
-        return values, refs
-
-    def _transform_value(self, children: list[Tree]) -> tuple[Any, Tree]:
-        """Given the children of a "key_value" rule, extract and transform the corresponding value.
-
-        Args:
-            children (List[Tree]): List of Lark branches containing the value to process. These should be the children
-                of a "key_value" rule.
-
-        Raises:
-            ValueError: If more than one value is found.
-
-        Returns:
-            Tuple[Any, Tree]: Transformed value, tree branch storing the corresponding value.
-        """
-        values, refs = self._transform_values(children)
-        if len(refs) > 1:
-            raise ValueError("More than one value found in Tree")
-        return values[0], refs[0]
-
-    def key_list(self, tree: Tree) -> None:
-        """Function to process "key_list" rules.
-
-        Args:
-            tree (Tree): Lark tree storing a "key_list" rule.
-        """
-        key = self._get_key(tree)
-        self._data[key], self._refs[key] = self._transform_values(tree.children)
-
-    def key_value(self, tree: Tree) -> None:
-        """Function to process "key_value" rules.
-
-        Args:
-            tree (Tree): Lark tree storing a "key_value" rule.
-        """
-        key = self._get_key(tree)
-        self._data[key], self._refs[key] = self._transform_value(tree.children)
-
-    def key_block(self, tree: Tree) -> None:
-        """Function to process "key_block" rules.
-
-        Args:
-            tree (Tree): Lark tree storing a "key_block" rule.
-        """
-        key = self._get_key(tree)
-        for child in tree.children:
-            if child.data == "block":
-                self._data[key] = Config(child, self._reconstructor, self._case_sensitive_keys)
-                self._refs[key] = child
-                return
-            else:
-                pass
-
-    def key_null(self, tree: Tree) -> None:
-        """Function to process "key_null" rules.
-
-        Args:
-            tree (Tree): Lark tree storing a "key_null" rule.
-        """
-        key = self._get_key(tree)
-        self._data[key] = None
-        self._refs[key] = tree

--- a/src/access/config/parser.py
+++ b/src/access/config/parser.py
@@ -25,14 +25,14 @@ class ConfigList(list):
     """A list subclass that keeps the parse tree in sync when individual elements are modified.
 
     When an element is updated via index assignment (e.g., ``config["key"][i] = new_value``), the corresponding
-    node in the Lark parse tree is also updated so that round-trip reconstruction reflects the change.
+    value-type rule node in the Lark parse tree is also updated so that round-trip reconstruction reflects the change.
 
     Args:
         data: The list data.
-        refs: List of references to the corresponding parse tree value nodes.
+        refs: List of references to the value-type rule nodes (one per list element).
     """
 
-    _refs: list[Tree]  # References to the value nodes of the parse tree
+    _refs: list[Tree]  # Value-type rule nodes from the parse tree, one per list element.
 
     def __init__(self, data: list[Any], refs: list[Tree]) -> None:
         super().__init__(data)
@@ -47,7 +47,8 @@ class ConfigList(list):
 
         Args:
             index: Integer index or slice of the element(s) to update.
-            value: New value (or iterable of values for slices).
+            value: New value (or iterable of values for slices). The type of each value
+                must match the type already stored in the corresponding value-type rule node.
 
         Raises:
             ValueError: If a slice assignment would change the list length.
@@ -68,7 +69,7 @@ class ConfigList(list):
 class Config(dict):
     """Class inheriting from dict used to store the contents of parsed configuration files.
 
-    For each entry we keep a reference to the corresponding branch in the parse tree so that we can update it when
+    For each entry we keep a reference to the corresponding rule node in the parse tree so that we can update it when
     changing the contents of the dict. This is then done by overriding the __setitem__ and __delitem__ methods.
 
     The class also adds support for case-insensitive keys by overriding the appropriate dict methods.
@@ -80,7 +81,11 @@ class Config(dict):
     """
 
     _tree: Tree  # The full parse tree
-    _refs: dict[str, list[Tree] | Tree]  # References to the nodes of the parse tree
+    _refs: dict[str, list[Tree] | Tree]
+    # References to rule nodes in the parse tree, keyed by config key:
+    #   scalar keys  → a single value-type rule node (Tree whose .data is in VALUE_TYPE_HANDLER_REGISTRY)
+    #   list keys    → a list of value-type rule nodes (one per element)
+    #   block keys   → the "block" rule node (Tree whose .data == "block")
     _reconstructor: Reconstructor  # Lark reconstructor used for round-trip parsing
     _case_sensitive_keys: bool  # Are the dict keys case insensitive?
 
@@ -133,8 +138,8 @@ class Config(dict):
         if len(refs) != len(value):
             raise ValueError(f"Trying to change the length of list '{key}'")
 
-        for branch, v in zip(refs, value, strict=True):
-            update_node_value(branch, v)
+        for rule_node, v in zip(refs, value, strict=True):
+            update_node_value(rule_node, v)
 
         return ConfigList(value, refs)
 
@@ -198,11 +203,11 @@ class Config(dict):
         # Remove item from the dict
         super().__delitem__(key)
 
-        # Remove the corresponding rule from the parse tree
-        rule = find_rule_node(self._refs[key])
-        rule.parent.children.remove(rule)  # type: ignore[attr-defined]
+        # Remove the key rule node from the parse tree
+        key_rule_node = find_rule_node(self._refs[key])
+        key_rule_node.parent.children.remove(key_rule_node)  # type: ignore[attr-defined]
 
-        # Finally remove reference to the branch storing the value
+        # Remove the rule node reference
         del self._refs[key]
 
     def __str__(self) -> str:
@@ -222,15 +227,16 @@ class ConfigParser(ABC):
       - list/array (e.g., 'a=1,2,3')
       - block/dict containing other key-value assignments (e.g., 'blk: b=1, c=2')
 
-    Because the resulting parse trees are all processed using the ConfigToDict Interpreter, all grammars must follow
-    the same structure and use the same names for the relevant rules:
-      - Key-value assignment rules must be named (or have an alias with that name): "key_value", "key_list" and
-        "key_block".
-      - Only rules from the "config.lark" file should be used when defining the supported scalar values in the
-        assignment rules.
-      - The rule defining what a key is must be named "key". Note that the "config.lark" file contains a "key" rule
-        that should work for most cases.
-      - Empty assignments (e.g., 'a=') are supported and the corresponding rule must be named "key_null".
+    Because the resulting parse trees are all processed using the ``ConfigToDict`` Interpreter, whose callbacks are
+    named after grammar rules, all grammars must follow the same structure and use the same rule names:
+
+      - Key-value assignment rules must be named (or aliased to): ``"key_value"``, ``"key_list"``, and
+        ``"key_block"``. The ``ConfigToDict`` Interpreter dispatches to methods of those exact names.
+      - Only value-type rules from ``"config.lark"`` should be used for scalar values. Their names must be registered
+        in ``VALUE_TYPE_HANDLER_REGISTRY``.
+      - The rule that captures the key name must be named ``"key"``. Its first child must be a ``Token`` (terminal)
+        whose text is the key string. The ``"config.lark"`` file provides a ``"key"`` rule suitable for most cases.
+      - Empty assignments (e.g., ``a=``) are supported. The corresponding rule must be named ``"key_null"``.
 
     This class is made abstract to prevent instantiation, as it requires a Lark grammar to be provided in order to work
     correctly.

--- a/src/access/config/parser_types.py
+++ b/src/access/config/parser_types.py
@@ -1,0 +1,117 @@
+# Copyright 2025 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Value type handlers for the configuration parser.
+
+This module defines ``ValueTypeHandler``, a dataclass that bundles the three operations needed
+to handle a single value type (type checking, parsing, and serialisation), and provides the
+``VALUE_TYPE_HANDLER_REGISTRY`` that maps grammar rule names to their handlers.
+"""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from lark import Token
+
+
+def _float_to_str(value: float, token: Token) -> str:
+    """Given a float and a Lark token, convert the float to a string using the same notation as used in the token.
+    This is to handle cases where the old Fortran notation is used (e.g.: 1.0d10 or 1.0D10).
+
+    Args:
+        value (float): float to be converted
+        token (Token): Lark token holding the float
+
+    Returns:
+        str: the float as a string
+    """
+    for c in token:
+        if c in ["D", "d", "E", "e"]:
+            return str(value).replace("e", c)
+    else:
+        return str(value)
+
+
+@dataclass(frozen=True)
+class ValueTypeHandler:
+    """Encapsulates all operations for a single value type.
+
+    Each handler bundles three operations related to a single value type:
+    - Type checking: a function that checks if a Python value matches this type.
+    - Parsing: a function that converts a Lark token string into the corresponding Python value.
+    - Serialisation: a function that converts a Python value back into the string representation used in the Lark token,
+      preserving any notation specifics (e.g. Fortran ``D`` exponent). This is used when updating the parse tree with
+      new values, to make sure that the formatting of the original file is preserved as much as possible.
+
+    Args:
+        type_check: Predicate that returns ``True`` when a Python value matches this type.
+        from_token: Converts a Lark token string into the corresponding Python value.
+        to_token: Converts a Python value back into the string representation used
+            in the Lark token, preserving any notation specifics (e.g. Fortran ``D`` exponent).
+    """
+
+    type_check: Callable[[Any], bool]
+    from_token: Callable[[str], Any]
+    to_token: Callable[[Any, str], Any]
+
+
+VALUE_TYPE_HANDLER_REGISTRY: dict[str, ValueTypeHandler] = {
+    "logical": ValueTypeHandler(
+        type_check=lambda value: type(value) is bool,
+        from_token=lambda token: str(token).lower() == ".true.",
+        to_token=lambda value, token: ".true." if value else ".false.",
+    ),
+    "bool": ValueTypeHandler(
+        type_check=lambda value: type(value) is bool,
+        from_token=lambda token: str(token) == "True",
+        to_token=lambda value, token: "True" if value else "False",
+    ),
+    "integer": ValueTypeHandler(
+        type_check=lambda value: type(value) is int,
+        from_token=lambda token: int(token),
+        to_token=lambda value, token: value,
+    ),
+    "float": ValueTypeHandler(
+        type_check=lambda value: type(value) is float,
+        from_token=lambda token: float(token),
+        to_token=lambda value, token: _float_to_str(value, token),
+    ),
+    "double": ValueTypeHandler(
+        type_check=lambda value: type(value) is float,
+        from_token=lambda token: float(token.replace("D", "E").replace("d", "e")),
+        to_token=lambda value, token: _float_to_str(value, token),
+    ),
+    "complex": ValueTypeHandler(
+        type_check=lambda value: type(value) is complex,
+        from_token=lambda token: complex(*map(float, token.strip("()").split(","))),
+        to_token=lambda value, token: (
+            "(" + _float_to_str(value.real, token) + ", " + _float_to_str(value.imag, token) + ")"
+        ),
+    ),
+    "double_complex": ValueTypeHandler(
+        type_check=lambda value: type(value) is complex,
+        from_token=lambda token: complex(*map(float, token.replace("D", "E").replace("d", "e").strip("()").split(","))),
+        to_token=lambda value, token: (
+            "(" + _float_to_str(value.real, token) + ", " + _float_to_str(value.imag, token) + ")"
+        ),
+    ),
+    "identifier": ValueTypeHandler(
+        type_check=lambda value: type(value) is str and value.isidentifier(),
+        from_token=lambda token: str(token),
+        to_token=lambda value, token: value,
+    ),
+    "string": ValueTypeHandler(
+        type_check=lambda value: type(value) is str,
+        from_token=lambda token: token[1:-1],
+        to_token=lambda value, token: token[0] + value + token[-1],
+    ),
+    "path": ValueTypeHandler(
+        type_check=lambda value: isinstance(value, Path),
+        from_token=lambda token: Path(token),
+        to_token=lambda value, token: str(value),
+    ),
+}
+"""Registry mapping grammar rule names to their ``ValueTypeHandler``.  Each handler knows how to check, parse,
+and serialise a single value type."""

--- a/src/access/config/parser_types.py
+++ b/src/access/config/parser_types.py
@@ -14,18 +14,20 @@ from pathlib import Path
 from typing import Any
 
 
-def _float_to_str(value: float, token: str) -> str:
-    """Given a float and a Lark token, convert the float to a string using the same notation as used in the token.
-    This is to handle cases where the old Fortran notation is used (e.g.: 1.0d10 or 1.0D10).
+def _float_to_str(value: float, token_text: str) -> str:
+    """Convert a float to a string using the same exponent notation as the original token text.
+
+    This preserves Fortran-style exponent notation (e.g. ``1.0d10`` or ``1.0D10``) when
+    round-trip serialising a value back into its token text.
 
     Args:
-        value (float): float to be converted
-        token (Token): Lark token holding the float
+        value (float): Float to be converted.
+        token_text (str): Text of the ``Token`` that previously held the float (i.e. ``Token.value``).
 
     Returns:
-        str: the float as a string
+        str: The float as a string.
     """
-    for c in token:
+    for c in token_text:
         if c in ["D", "d", "E", "e"]:
             return str(value).replace("e", c)
     else:
@@ -37,22 +39,26 @@ class ValueTypeHandler:
     """Encapsulates all operations for a single value type.
 
     Each handler bundles three operations related to a single value type:
+
     - Type checking: a function that checks if a Python value matches this type.
-    - Parsing: a function that converts a Lark token string into the corresponding Python value.
-    - Serialisation: a function that converts a Python value back into the string representation used in the Lark token,
-      preserving any notation specifics (e.g. Fortran ``D`` exponent). This is used when updating the parse tree with
-      new values, to make sure that the formatting of the original file is preserved as much as possible.
+    - Parsing: a function that converts **token text** into the corresponding Python value.
+      Token text is the string matched by a grammar terminal. It is the ``str`` value of the
+      ``Token`` object (since ``Token`` is a subclass of ``str``, it can be passed directly).
+    - Serialisation: a function that converts a Python value back into token text, given
+      the previous token text so that notation specifics (e.g. Fortran ``D`` exponent) can
+      be preserved. This is used when updating value-type rule nodes with new values.
 
     Args:
         type_check: Predicate that returns ``True`` when a Python value matches this type.
-        from_token: Converts a Lark token string into the corresponding Python value.
-        to_token: Converts a Python value back into the string representation used
-            in the Lark token, preserving any notation specifics (e.g. Fortran ``D`` exponent).
+        from_token: Converts token text (the ``str`` value matched by the terminal) into the
+            corresponding Python value.
+        to_token: Converts a Python value back into token text, given the previous token text
+            (to preserve notation, e.g. Fortran ``D`` exponent).
     """
 
     type_check: Callable[[Any], bool]
     from_token: Callable[[str], Any]
-    to_token: Callable[[Any, str], Any]
+    to_token: Callable[[Any, str], str]
 
 
 VALUE_TYPE_HANDLER_REGISTRY: dict[str | None, ValueTypeHandler] = {
@@ -69,7 +75,7 @@ VALUE_TYPE_HANDLER_REGISTRY: dict[str | None, ValueTypeHandler] = {
     "integer": ValueTypeHandler(
         type_check=lambda value: type(value) is int,
         from_token=lambda token: int(token),
-        to_token=lambda value, token: value,
+        to_token=lambda value, token: str(value),
     ),
     "float": ValueTypeHandler(
         type_check=lambda value: type(value) is float,
@@ -111,5 +117,8 @@ VALUE_TYPE_HANDLER_REGISTRY: dict[str | None, ValueTypeHandler] = {
         to_token=lambda value, token: str(value),
     ),
 }
-"""Registry mapping grammar rule names to their ``ValueTypeHandler``.  Each handler knows how to check, parse,
-and serialise a single value type."""
+"""Registry mapping value-type rule names to their ``ValueTypeHandler``.
+
+Value-type rules are the grammar rules that appear as alternatives of the ``value`` rule
+(e.g. ``"integer"``, ``"float"``, ``"logical"``).  Each rule name maps to a handler that
+knows how to check, parse, and serialise the corresponding Python type."""

--- a/src/access/config/parser_types.py
+++ b/src/access/config/parser_types.py
@@ -13,10 +13,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from lark import Token
 
-
-def _float_to_str(value: float, token: Token) -> str:
+def _float_to_str(value: float, token: str) -> str:
     """Given a float and a Lark token, convert the float to a string using the same notation as used in the token.
     This is to handle cases where the old Fortran notation is used (e.g.: 1.0d10 or 1.0D10).
 
@@ -57,7 +55,7 @@ class ValueTypeHandler:
     to_token: Callable[[Any, str], Any]
 
 
-VALUE_TYPE_HANDLER_REGISTRY: dict[str, ValueTypeHandler] = {
+VALUE_TYPE_HANDLER_REGISTRY: dict[str | None, ValueTypeHandler] = {
     "logical": ValueTypeHandler(
         type_check=lambda value: type(value) is bool,
         from_token=lambda token: str(token).lower() == ".true.",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,7 +10,7 @@ from access.config.parser import ConfigParser
 grammar = """
     // Made-up grammar taylored to test the different building blocks
     // of the configuration parsers.
-    start: (key_block|outer_key_value|outer_key_list|key_null|wrong_key_value1|wrong_key_value2)+
+    start: (key_block|outer_key_value|outer_key_list|key_null|wrong_key_value1|wrong_key_value2|wrong_key_value3)+
 
     key_null: key equal
     outer_key_value: key equal value -> key_value
@@ -29,6 +29,9 @@ grammar = """
     // This rule will trip the interpreter because there is no value
     // (the alias should therefore be key_null)
     ?wrong_key_value2:  key colon equal -> key_value
+
+    // This rule will trip the interpreter because there is no "key" child node
+    ?wrong_key_value3:  "!" value -> key_value
 
     ?value: logical
          | bool
@@ -407,6 +410,10 @@ def test_config_invalid_rules(parser):
     # key_value rule that returns no value
     with pytest.raises(ValueError):
         parser.parse("a := \n")
+
+    # key_value rule that has no "key" child node
+    with pytest.raises(ValueError):
+        parser.parse("! 1\n")
 
 
 def test_config_invalid_operations(parser):


### PR DESCRIPTION
Several changes to the config parser base classes:
     - Consolidate all handling of value-type operations to a single registry
     - Move value-type handling to its own file.
     - Move classes and methods that manipulate the parse tree to its own file.
     - Several small improvements in the remaining classes.
     - Improve documentation.
 
This should make the core more readable and easier to maintain.

Also took the opportunity to fix type hints, adding a few assertions on parameter types to make the code more robust.